### PR TITLE
Fix scroll listener leak causing parallax lag

### DIFF
--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -69,7 +69,7 @@ export const Header = ({
   useEffect(() => {
     componentDidMount();
     return componentWillUnmount;
-  });
+  }, []);
 
   if (burgerRef.current)
     burgerRef.current.onclick = () => {

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -25,60 +25,61 @@ export const Header = ({
   const [showMenu, setShowMenu] = useState<boolean>(false);
 
   const burgerRef = useRef<HTMLDivElement>(null);
-
-  const resizeEvent = () => {
-    setWindowWidth(window.innerWidth);
-  };
-
-  const scrollEvent = () => {
-    if (forceColor) return;
-
-    if (showMenu) {
-      setTransparent(false);
-    } else {
-      if (window.scrollY >= scrollBreakpoint) {
-        if (transparent) {
-          setTransparent(false);
-        }
-      } else {
-        if (!transparent) {
-          setTransparent(true);
-        }
-      }
-    }
-  };
-
-  const componentDidMount = () => {
-    if (burgerRef.current)
-      burgerRef.current.onclick = () => {
-        if (!showMenu) {
-          setTransparent(false);
-        } else if (window.scrollY <= scrollBreakpoint) setTransparent(true);
-
-        setShowMenu(!showMenu);
-      };
-    window.addEventListener('resize', resizeEvent);
-    window.addEventListener('scroll', scrollEvent);
-  };
-
-  const componentWillUnmount = () => {
-    window.removeEventListener('resize', resizeEvent);
-    window.removeEventListener('scroll', scrollEvent);
-  };
+  const showMenuRef = useRef(showMenu);
+  const transparentRef = useRef(transparent);
 
   useEffect(() => {
-    componentDidMount();
-    return componentWillUnmount;
-  }, []);
+    showMenuRef.current = showMenu;
+  }, [showMenu]);
 
-  if (burgerRef.current)
-    burgerRef.current.onclick = () => {
-      if (!showMenu) {
-        setTransparent(false);
-      } else if (window.scrollY <= scrollBreakpoint) setTransparent(true);
+  useEffect(() => {
+    transparentRef.current = transparent;
+  }, [transparent]);
 
-      setShowMenu(!showMenu);
+  useEffect(() => {
+    const resizeEvent = () => {
+      setWindowWidth(window.innerWidth);
     };
+
+    const scrollEvent = () => {
+      if (forceColor) return;
+
+      if (showMenuRef.current) {
+        setTransparent(false);
+      } else {
+        if (window.scrollY >= scrollBreakpoint) {
+          if (transparentRef.current) {
+            setTransparent(false);
+          }
+        } else {
+          if (!transparentRef.current) {
+            setTransparent(true);
+          }
+        }
+      }
+    };
+
+    const burger = burgerRef.current;
+    if (burger) {
+      burger.onclick = () => {
+        if (!showMenuRef.current) {
+          setTransparent(false);
+        } else if (window.scrollY <= scrollBreakpoint) {
+          setTransparent(true);
+        }
+        setShowMenu(!showMenuRef.current);
+      };
+    }
+
+    window.addEventListener('resize', resizeEvent);
+    window.addEventListener('scroll', scrollEvent, { passive: true });
+
+    return () => {
+      window.removeEventListener('resize', resizeEvent);
+      window.removeEventListener('scroll', scrollEvent);
+      if (burger) burger.onclick = null;
+    };
+  }, [forceColor]);
 
   return windowWidth >= mobileBreakpoint ? (
     <nav

--- a/src/Hooks/useScrollTop.ts
+++ b/src/Hooks/useScrollTop.ts
@@ -5,14 +5,19 @@ type ScrollPosition = {
   scrollY: number;
 };
 
-function getScrollPosition(): ScrollPosition {
-  const { scrollX, scrollY } = window;
-  return { scrollX, scrollY };
+let scrollPosition: ScrollPosition = {
+  scrollX: window.scrollX,
+  scrollY: window.scrollY,
+};
+
+function getSnapshot(): ScrollPosition {
+  return scrollPosition;
 }
 
 const listeners = new Set<() => void>();
 
 function onScroll() {
+  scrollPosition = { scrollX: window.scrollX, scrollY: window.scrollY };
   listeners.forEach((listener) => listener());
 }
 
@@ -30,5 +35,5 @@ function subscribe(listener: () => void) {
 }
 
 export default function useScrollTop(): ScrollPosition {
-  return useSyncExternalStore(subscribe, getScrollPosition, getScrollPosition);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/src/Hooks/useScrollTop.ts
+++ b/src/Hooks/useScrollTop.ts
@@ -13,12 +13,12 @@ export default function useScrollTop() {
   const [windowDimensions, setWindowDimensions] = useState(getScrollTop());
 
   useEffect(() => {
-    function handleResize() {
+    function handleScroll() {
       setWindowDimensions(getScrollTop());
     }
 
-    window.addEventListener('scroll', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
   return windowDimensions;


### PR DESCRIPTION
## Summary
- fix scroll listener cleanup and add passive option
- prevent repeated header event listener registration

## Testing
- `npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f41f91d88324a25d31aaa2e735c8